### PR TITLE
modprobe.d: Disable the watchdog on Steam Deck Handhelds

### DIFF
--- a/usr/lib/modprobe.d/blacklist-handheld.conf
+++ b/usr/lib/modprobe.d/blacklist-handheld.conf
@@ -1,0 +1,1 @@
+blacklist wdat_wdt


### PR DESCRIPTION
It has been reported that watchdog is still running even if `nowatchdog` has been passed in the boot parameters on Steam Deck Handhelds. Disable the additional watchdog that Steam Deck has by blacklisting it via modprobe configs.

Closes #37