### PR TITLE
Added os-branch-select script

### DIFF
--- a/usr/lib/os-branch-select
+++ b/usr/lib/os-branch-select
@@ -2,15 +2,11 @@
 
 set -e
 
-os_name=$(grep '^NAME=' /etc/os-release 2>/dev/null | cut -d= -f2- | tr -d '"')
+os_name="$(grep '^NAME=' /etc/os-release 2>/dev/null | cut -d= -f2- | tr -d '"')"
 
 if [[ $# -eq 1 ]]; then
   case "$1" in
-    -c)
-      echo "$os_name"
-      exit 0
-      ;;
-    -l)
+    -c|-l)
       echo "$os_name"
       exit 0
       ;;

--- a/usr/lib/os-branch-select
+++ b/usr/lib/os-branch-select
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+os_name=$(grep '^NAME=' /etc/os-release 2>/dev/null | cut -d= -f2- | tr -d '"')
+
+if [[ $# -eq 1 ]]; then
+  case "$1" in
+    -c)
+      echo "$os_name"
+      exit 0
+      ;;
+    -l)
+      echo "$os_name"
+      exit 0
+      ;;
+    stable)
+      exit 0
+      ;;
+    *)
+      echo "Invalid option. Usage: steamos-select-branch <stable|-c|-l>" 1>&2
+      exit 1
+      ;;
+  esac
+fi
+
+echo "Usage: steamos-select-branch <stable|-c|-l>" 1>&2


### PR DESCRIPTION
This request includes adding the `os-branch-select` script. In fact, it doesn't provide an option to change the channel and just displays the distribution name (CachyOS Linux) instead of the «No branch script was found» message.

<details>
  <img src="https://github.com/user-attachments/assets/7196f15b-4bfc-4e9b-913e-2e4928bce667" width="672">
</details>