### PR TITLE
audio: msi-claw: Add wireplumber config to increase ALSA headroom

### DIFF
--- a/usr/share/cachyos-handheld/msi-claw/wireplumber/alsa-card0.conf
+++ b/usr/share/cachyos-handheld/msi-claw/wireplumber/alsa-card0.conf
@@ -1,0 +1,15 @@
+# MSI Claw has issues with audio cutting out, this works around it
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        node.name = "~alsa_output.pci-0000_00_1f.3*"
+      }
+    ]
+    actions = {
+      update-props = {
+        api.alsa.headroom      = 1024
+      }
+    }
+  }
+]


### PR DESCRIPTION
The MSI Claw needs this to have stable audio, otherwise "audio cutoff fuckery" can happen.

Link: https://github.com/matte-schwartz/claw-steamos