### PR TITLE
feat: add decky loader install shortcut to handheld desktop

### DIFF
--- a/etc/skel/Desktop/decky_installer.desktop
+++ b/etc/skel/Desktop/decky_installer.desktop
@@ -1,0 +1,8 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Name=Install Decky
+Exec=sh -c 'rm -f /tmp/user_install_script.sh; if curl -S -s -L -O --output-dir /tmp/ --connect-timeout 60 https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/user_install_script.sh; then bash /tmp/user_install_script.sh; else echo "Something went wrong, please report this if it is a bug"; read; fi'
+Icon=steamdeck-gaming-return
+Terminal=true
+Type=Application
+StartupNotify=false


### PR DESCRIPTION
adding a .desktop file to handheld edition to streamline acquisition of decky loader