### PR TITLE
Move steamos-gamemode.desktop and replace 'qdbus' with 'qdbus6' 

### DIFF
--- a/etc/skel/Desktop/steamos-gamemode.desktop
+++ b/etc/skel/Desktop/steamos-gamemode.desktop
@@ -1,7 +1,1 @@
-[Desktop Entry]
-Name=Return to Gaming Mode
-Exec=qdbus org.kde.Shutdown /Shutdown org.kde.Shutdown.logout
-Icon=steamdeck-gaming-return
-Terminal=false
-Type=Application
-StartupNotify=false
+/usr/share/applications/steamos-gamemode.desktop

--- a/usr/share/applications/steamos-gamemode.desktop
+++ b/usr/share/applications/steamos-gamemode.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Return to Gaming Mode
+Exec=qdbus6 org.kde.Shutdown /Shutdown org.kde.Shutdown.logout
+Icon=steamdeck-gaming-return
+Terminal=false
+Type=Application
+StartupNotify=false


### PR DESCRIPTION
Moving the file to the standard /usr/share/applications should help ameliorate some of those pesky 'where is the desktop file' queries. 

A symlink is included to that desktop file in /etc/skel to retain the current behavior of providing a shortcut on the desktop to new users. 

Finally a small adjustment to the execution - replacing 'qdbus' with 'qdbus6' further protects against any cases in which the qdbus executable does not exist or does not exist in PATH. The only package providing 'qdbus' this way is 'qt5-tools', and it is not necessarily present or required. 
