### PR TITLE
Remove unnecessary hook targets

### DIFF
--- a/usr/share/libalpm/hooks/blocked-packages.hook
+++ b/usr/share/libalpm/hooks/blocked-packages.hook
@@ -3,8 +3,6 @@ Operation = Install
 Operation = Upgrade
 Type = Package
 Target = packagekit
-Target = packagekit-qt6
-Target = packagekit-qt5
 
 [Action]
 Description = "The transaction is attempting to install packagekit. Packagekit is broken on arch and should not be used. Transaction cancelled."


### PR DESCRIPTION
`packagekit-qtX` depends on `packagekit`.

CC: @1Naim.