### PR TITLE
Disable file and Flatpak search

### DIFF
--- a/etc/xdg/krunnerrc
+++ b/etc/xdg/krunnerrc
@@ -1,0 +1,3 @@
+[Plugins]
+baloosearchEnabled=false
+krunner_appstreamEnabled=false


### PR DESCRIPTION
- Baloo indexing is disabled by default
- Flatpak is not installed by default

CC: @1Naim 